### PR TITLE
Allow empty statustext for successful requests to be http2 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+﻿################################################################################
+# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
+################################################################################
+
+/AjaxPro/obj/Debug/AjaxPro.csproj.AssemblyReference.cache
+/.vs/slnx.sqlite
+/.vs/Ajax.NET-Professional/v17/.suo

--- a/AjaxPro/core.js
+++ b/AjaxPro/core.js
@@ -355,8 +355,9 @@ AjaxPro.Request.prototype = {
 			clearTimeout(this.timeoutTimer);
 		}
 		var res = this.getEmptyRes();
-		if(this.xmlHttp.status == 200 && this.xmlHttp.statusText == "OK") {
-			res = this.createResponse(res);
+		//Ignore empty statustext to be http2 compatible
+		if (this.xmlHttp.status == 200 && this.xmlHttp.statusText == "OK" || !this.xmlHttp.statusText) {
+			res = this.createResponse(res); 
 		} else {
 			res = this.createResponse(res, true);
 			res.error = {Message:this.xmlHttp.statusText,Type:"ConnectFailure",Status:this.xmlHttp.status};


### PR DESCRIPTION
Fix for http2 bug: statustext can be empty when using http2 and status is 200. The core.js script couldn't handle that.